### PR TITLE
Allow to enter story with leading '#' (e.g: #1234)

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -5,6 +5,7 @@ import sublime, sublime_plugin
 from urllib.request import Request, urlopen
 import json
 import os
+import re
 
 #
 # Opciones de configuracion
@@ -114,6 +115,8 @@ class PluginUtils:
     """
     if projectID == '' or storyID == '' or apiToken == '':
       return
+    # if story contains leading '#' remove it
+    storyID = re.sub('^#', '', storyID)
     url = PIVOTAL_TRACKER_URL.format(projectID, storyID)
     req = Request(url)
     req.add_header('X-TrackerToken', apiToken)


### PR DESCRIPTION
An easy way to get a story ID from Pivotal Tracker is to press the
button with the text "ID" on the story form of Tracker's Web UI. The
problem with that is that it includes the leading '#' (e.g. #101899896)
and this plugin currently fails if you include it on the "Get Story"
prompt. So one has to paste the story ID on the clipboard and then
go to the start of the prompt text and remove the '#'.

Allow to optionally include the trailing '#' in order to make it easier
to just copy/paste the story's ID.

Achieve this by removing the trailing '#' if it is present.
