### PR TITLE
Fix exception on empty preference file

### DIFF
--- a/story_to_jasmine.py
+++ b/story_to_jasmine.py
@@ -93,13 +93,13 @@ class StoryParse(object):
         self.__it_list = []
         self.__lang_tokens = {}
         self.__lang_tokens['word_given'] = \
-            PluginUtils.get_pref('word_Given').strip() + ' '
+            (PluginUtils.get_pref('word_Given') or '').strip() + ' '
         self.__lang_tokens['word_and'] = \
-            PluginUtils.get_pref('word_And').strip() + ' '
+            (PluginUtils.get_pref('word_And') or '').strip() + ' '
         self.__lang_tokens['word_when'] = \
-            PluginUtils.get_pref('word_When').strip() + ' '
+            (PluginUtils.get_pref('word_When') or '').strip() + ' '
         self.__lang_tokens['word_then'] = \
-            PluginUtils.get_pref('word_Then').strip() + ' '
+            (PluginUtils.get_pref('word_Then') or '').strip() + ' '
         self.__lang_tokens['it_template'] = \
             PluginUtils.get_pref('it_template')
         self.__lang_tokens['describe_template'] = \


### PR DESCRIPTION
Fix exception that gets thrown when the preference file is empty or a
certain property in that file doesn't exist. This exception is usually
thrown when sublime is booting, during the process of loading packages,
done by Package Control

This could be causing the plugin to be disabled after restarting
sublime for some users.
